### PR TITLE
Incorrect SQL parameter names in validateAuthCode

### DIFF
--- a/Library/Sum/Oauth2/Server/Storage/Pdo/Mysql/Session.php
+++ b/Library/Sum/Oauth2/Server/Storage/Pdo/Mysql/Session.php
@@ -240,7 +240,7 @@ class Session implements SessionInterface
             AND $oSA.auth_code_expires >= :time
             AND $oSR.redirect_uri = :redirectUri",
             Db::FETCH_ASSOC,
-            ['clientId' => $clientId, 'redirect_uri' => $redirectUri, 'auth_code' => $authCode, 'time' => time()]
+            ['clientId' => $clientId, 'redirectUri' => $redirectUri, 'authCode' => $authCode, 'time' => time()]
         );
 
         if (!empty($row)) {


### PR DESCRIPTION
When executing validateAuthCode function, an "SQLSTATE[HY093]: Invalid parameter number: parameter was not defined" exception occurs. Parameters :redirectUri and :authCode are not being matched properly.

I propose renaming 'redirect_uri' to 'redirectUri', and 'auth_code' to 'authCode', so parameters will be matching correctly.
